### PR TITLE
Update OSCReceiver.py

### DIFF
--- a/python/OSCReceiver/OSCReceiver.py
+++ b/python/OSCReceiver/OSCReceiver.py
@@ -24,6 +24,7 @@ def handle_osc_message(address, *args):
 
     try:
         dot_index = int(args[0])
+        device = devices[dot_index]
         command = str(args[1]).lower()
     except ValueError:
         print("Invalid dot index or command.")


### PR DESCRIPTION
Allow script to communicate with all devices via indexing, per documentation. 

When I was using this before it would only ever send messages to the first device in the list, as the dot_index parameter didn't actually affect the “device” variable past the initialization.